### PR TITLE
 Allow NUM_{WIFI/BLYNK}_CREDENTIALS to be overridden. (ESP8266)

### DIFF
--- a/src/BlynkSimpleEsp8266_GSM_Async_WFM.h
+++ b/src/BlynkSimpleEsp8266_GSM_Async_WFM.h
@@ -226,8 +226,13 @@ typedef struct
   char gsm_blynk_token  [BLYNK_TOKEN_MAX_LEN];
 }  Blynk_Credentials;
 
-#define NUM_WIFI_CREDENTIALS      2
-#define NUM_BLYNK_CREDENTIALS     2
+
+#ifndef NUM_WIFI_CREDENTIALS
+  #define NUM_WIFI_CREDENTIALS      2
+#endif
+#ifndef NUM_BLYNK_CREDENTIALS
+  #define NUM_BLYNK_CREDENTIALS     2
+#endif
 
 // Configurable items besides fixed Header
 #define NUM_CONFIGURABLE_ITEMS    ( 6 + (2 * NUM_WIFI_CREDENTIALS) + (3 * NUM_BLYNK_CREDENTIALS) )


### PR DESCRIPTION
Currently, `NUM_WIFI_CREDENTIALS` and `NUM_BLYNK_CREDENTIALS` are `#define`d in `BlynkSimpleEsp8266_GSM_Async_WFM.h`, meaning that they can't be overridden (without modifying that file, at least). This change wraps these definitions in `#ifndef`s so that they will only be set if they aren't already, allowing those values to act as defaults but still be overridable.